### PR TITLE
Fix the problem with the latest version of do-wrapper

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const DigitalOcean = require('do-wrapper');
+const DigitalOcean = require('do-wrapper').default;
 const Promise = require('bluebird');
 const dns = Promise.promisifyAll(require('dns'));
 


### PR DESCRIPTION
Current version of do-wrapper requires a `.default` after `require`.

I installed `le-channge-digitalocean` and it throw an error on this line. This change fixed that and the package worked after this.